### PR TITLE
gitignore: ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /*.ipynb
 *.DAT
 docs/api/summary
+__pycache__
+*.egg-info


### PR DESCRIPTION
Ignore `__pycache__` and `*.egg-info` left by `pip install -e .` .