### PR TITLE
Update tree_map -> tree_util.tree_map to avoid FutureWarning

### DIFF
--- a/docs/tutorials/means.ipynb
+++ b/docs/tutorials/means.ipynb
@@ -222,7 +222,7 @@
     "import jaxopt\n",
     "\n",
     "solver = jaxopt.ScipyMinimize(fun=loss)\n",
-    "soln = solver.run(jax.tree_map(jnp.asarray, params))\n",
+    "soln = solver.run(jax.tree_util.tree_map(jnp.asarray, params))\n",
     "print(f\"Final negative log likelihood: {soln.state.fun_val}\")"
    ]
   },

--- a/docs/tutorials/quasisep.ipynb
+++ b/docs/tutorials/quasisep.ipynb
@@ -185,7 +185,7 @@
     "import jaxopt\n",
     "\n",
     "solver = jaxopt.ScipyMinimize(fun=loss)\n",
-    "soln = solver.run(jax.tree_map(jnp.asarray, params))\n",
+    "soln = solver.run(jax.tree_util.tree_map(jnp.asarray, params))\n",
     "print(f\"Final negative log likelihood: {soln.state.fun_val}\")"
    ]
   },

--- a/news/114.bugfix
+++ b/news/114.bugfix
@@ -1,0 +1,1 @@
+Fixed ``FutureWarning`` by updating ``tree_map`` to ``tree_util.tree_map``.

--- a/src/tinygp/kernels/quasisep.py
+++ b/src/tinygp/kernels/quasisep.py
@@ -118,11 +118,11 @@ class Quasisep(Kernel, metaclass=ABCMeta):
         pu = h2 @ Pinf
 
         i = jnp.clip(idx, 0, ql.shape[0] - 1)
-        Xi = jax.tree_map(lambda x: jnp.asarray(x)[i], X2)
+        Xi = jax.tree_util.tree_map(lambda x: jnp.asarray(x)[i], X2)
         pl = jax.vmap(jnp.dot)(pl, jax.vmap(self.transition_matrix)(Xi, X1))
 
         i = jnp.clip(idx + 1, 0, pu.shape[0] - 1)
-        Xi = jax.tree_map(lambda x: jnp.asarray(x)[i], X2)
+        Xi = jax.tree_util.tree_map(lambda x: jnp.asarray(x)[i], X2)
         qu = jax.vmap(jnp.dot)(jax.vmap(self.transition_matrix)(X1, Xi), qu)
 
         return GeneralQSM(pl=pl, ql=ql, pu=pu, qu=qu, a=a, idx=idx)


### PR DESCRIPTION
Thanks for putting together this package - finding it really useful (especially the NumPyro integration)!

This should close up #110 when merged - all usages of `tree_map` are now updated to avoid throwing the `FutureWarning`.