### PR TITLE
Adding check for unsorted input coordinates when using QuasisepSolver

### DIFF
--- a/docs/tutorials/quasisep-custom.ipynb
+++ b/docs/tutorials/quasisep-custom.ipynb
@@ -670,7 +670,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.6 ('tinygp')",
    "language": "python",
    "name": "python3"
   },
@@ -684,7 +684,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.10.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "d20ea8a315da34b3e8fab0dbd7b542a0ef3c8cf12937343660e6bc10a20768e3"
+   }
   }
  },
  "nbformat": 4,

--- a/news/123.feature
+++ b/news/123.feature
@@ -1,0 +1,2 @@
+Added check for sorted input coordinates when using the ``QuasisepSolver``;
+a ``ValueError`` is thrown if they are not.

--- a/src/tinygp/gp.py
+++ b/src/tinygp/gp.py
@@ -66,6 +66,7 @@ class GaussianProcess:
         solver: Optional[Any] = None,
         mean_value: Optional[JAXArray] = None,
         covariance_value: Optional[Any] = None,
+        **solver_kwargs: Any,
     ):
         self.kernel = kernel
         self.X = X
@@ -101,7 +102,11 @@ class GaussianProcess:
             else:
                 solver = DirectSolver
         self.solver = solver.init(
-            kernel, self.X, self.noise, covariance=covariance_value
+            kernel,
+            self.X,
+            self.noise,
+            covariance=covariance_value,
+            **solver_kwargs,
         )
 
     @property

--- a/src/tinygp/kernels/quasisep.py
+++ b/src/tinygp/kernels/quasisep.py
@@ -204,6 +204,9 @@ class Wrapper(Quasisep, metaclass=ABCMeta):
 
     kernel: Quasisep
 
+    def coord_to_sortable(self, X: JAXArray) -> JAXArray:
+        return self.kernel.coord_to_sortable(X)
+
     def design_matrix(self) -> JAXArray:
         return self.kernel.design_matrix()
 
@@ -225,6 +228,10 @@ class Sum(Quasisep):
 
     kernel1: Quasisep
     kernel2: Quasisep
+
+    def coord_to_sortable(self, X: JAXArray) -> JAXArray:
+        """We assume that both kernels use the same coordinates"""
+        return self.kernel1.coord_to_sortable(X)
 
     def design_matrix(self) -> JAXArray:
         return jsp.linalg.block_diag(
@@ -258,6 +265,10 @@ class Product(Quasisep):
 
     kernel1: Quasisep
     kernel2: Quasisep
+
+    def coord_to_sortable(self, X: JAXArray) -> JAXArray:
+        """We assume that both kernels use the same coordinates"""
+        return self.kernel1.coord_to_sortable(X)
 
     def design_matrix(self) -> JAXArray:
         F1 = self.kernel1.design_matrix()

--- a/src/tinygp/kernels/quasisep.py
+++ b/src/tinygp/kernels/quasisep.py
@@ -27,7 +27,7 @@ __all__ = [
 ]
 
 from abc import ABCMeta, abstractmethod
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import jax
 import jax.numpy as jnp
@@ -151,7 +151,7 @@ class Quasisep(Kernel, metaclass=ABCMeta):
             )
         return Sum(self, other)
 
-    def __radd__(self, other: Union["Kernel", JAXArray]) -> "Kernel":
+    def __radd__(self, other: Any) -> "Kernel":
         # We'll hit this first branch when using the `sum` function
         if other == 0:
             return self
@@ -171,7 +171,7 @@ class Quasisep(Kernel, metaclass=ABCMeta):
             )
         return Scale(kernel=self, scale=other)
 
-    def __rmul__(self, other: Union["Kernel", JAXArray]) -> "Kernel":
+    def __rmul__(self, other: Any) -> "Kernel":
         if isinstance(other, Quasisep):
             return Product(other, self)
         if isinstance(other, Kernel) or jnp.ndim(other) != 0:
@@ -699,14 +699,14 @@ class CARMA(Quasisep):
         params = jnp.linalg.solve(
             params, 0.5 * sigma**2 * jnp.eye(p, 1, k=-p + 1)
         )[:, 0]
-        stn = []
+        stn_ = []
         for j in range(p):
-            stn.append([jnp.zeros(()) for _ in range(p)])
+            stn_.append([jnp.zeros(()) for _ in range(p)])
             for n, k in enumerate(range(j - 2, -1, -2)):
-                stn[-1][k] = (2 * (n % 2) - 1) * params[j - n - 1]
+                stn_[-1][k] = (2 * (n % 2) - 1) * params[j - n - 1]
             for n, k in enumerate(range(j, p, 2)):
-                stn[-1][k] = (1 - 2 * (n % 2)) * params[n + j]
-        stn = jnp.array(list(map(jnp.stack, stn)))
+                stn_[-1][k] = (1 - 2 * (n % 2)) * params[n + j]
+        stn = jnp.array(list(map(jnp.stack, stn_)))
 
         return cls(
             sigma=sigma,


### PR DESCRIPTION
A simpler way to fix #109

Instead of #117, in this PR, we simply check that the coordinates are sorted and throw an error if they are not. I'd love to get #117 working, but I can't seem to get the logic working in a simple way so I'm inclined to get this merged to get _something_ implemented!