### PR TITLE
Fixing behavior of DotProduct kernel on scalar inputs

### DIFF
--- a/news/124.bugfix
+++ b/news/124.bugfix
@@ -1,0 +1,1 @@
+Fixed behavior of DotProduct kernel on scalar inputs.

--- a/src/tinygp/kernels/base.py
+++ b/src/tinygp/kernels/base.py
@@ -234,6 +234,8 @@ class DotProduct(Kernel):
     """
 
     def evaluate(self, X1: JAXArray, X2: JAXArray) -> JAXArray:
+        if jnp.ndim(X1) == 0:
+            return X1 * X2
         return X1 @ X2
 
 

--- a/tests/test_kernels/test_kernels.py
+++ b/tests/test_kernels/test_kernels.py
@@ -82,3 +82,12 @@ def test_conditioned(data):
             cond(x1, x2),
             k2(x1, x2) - k2(x1, x1) @ jnp.linalg.solve(K, k2(x1, x2)),
         )
+
+
+def test_dot_product(data):
+    x1, x2 = data
+    kernel = kernels.DotProduct()
+    np.testing.assert_allclose(kernel(x1, x2), jnp.dot(x1, x2.T))
+    np.testing.assert_allclose(
+        kernel(x1[:, 0], x2[:, 0]), x1[:, 0][:, None] * x2[:, 0][None]
+    )


### PR DESCRIPTION
fixes #111 