### PR TITLE
Move post_init check into eval for kernels which provide it.

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -11,6 +11,11 @@
       "name": "Yadav, Sachin"
     },
     {
+      "orcid": "0009-0000-1930-8150",
+      "affiliation": "Massachusetts Institute of Technology, Probabilistic Computing Project, Cambridge, MA, USA",
+      "name": "Becker, McCoy Reynolds"
+    },
+    {
       "orcid": "0000-0002-0440-9597",
       "name": "Killestein, Thomas",
       "affiliation": "Department of Physics, University of Warwick, Coventry, UK"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -4,6 +4,30 @@
       "orcid": "0000-0002-9328-5652",
       "affiliation": "Center for Computational Astrophysics, Flatiron Institute, New York, NY, USA",
       "name": "Foreman-Mackey, Daniel"
+    },
+    {
+      "orcid": "0000-0003-0048-1118",
+      "affiliation": "Indian Institute of Technology Gandhinagar: Gandhinagar, Gujarat, IN",
+      "name": "Yadav, Sachin"
+    },
+    {
+      "orcid": "0000-0002-0440-9597",
+      "name": "Killestein, Thomas",
+      "affiliation": "Department of Physics, University of Warwick, Coventry, UK"
+    },
+    {
+      "affiliation": "School of Public Health, Imperial College London, UK",
+      "name": "Rashid, Theo"
+    },
+    {
+      "orcid": "0000-0003-1354-0578",
+      "affiliation": "Helmholtz-Zentrum Dresden-Rossendorf e.V.",
+      "name": "Schmerler, Steve"
+    },
+    {
+      "orcid": "0000-0003-1001-0707",
+      "affiliation": "Department of Physics and Astronomy, Aarhus University, DK",
+      "name": "Tronsgaard, René"
     }
   ],
   "license": "MIT",

--- a/news/148.feature
+++ b/news/148.feature
@@ -1,0 +1,1 @@
+Removed `__post_init__` checks after kernel construction to avoid extraneous errors when returning kernels out of `jax.vmap`'d functions.

--- a/news/154.doc
+++ b/news/154.doc
@@ -1,0 +1,1 @@
+Added past contributor metadata to `.zenodo.json`.

--- a/src/tinygp/kernels/base.py
+++ b/src/tinygp/kernels/base.py
@@ -214,11 +214,9 @@ class Constant(Kernel):
 
     value: JAXArray
 
-    def __post_init__(self) -> None:
+    def evaluate(self, X1: JAXArray, X2: JAXArray) -> JAXArray:
         if jnp.ndim(self.value) != 0:
             raise ValueError("The value of a constant kernel must be a scalar")
-
-    def evaluate(self, X1: JAXArray, X2: JAXArray) -> JAXArray:
         return self.value
 
 

--- a/tests/test_kernels/test_kernels.py
+++ b/tests/test_kernels/test_kernels.py
@@ -25,13 +25,16 @@ def data(random):
 def test_constant(data):
     x1, x2 = data
 
-    # Check for dimension issues, either when instantiated...
+    # Check for dimension issues when evaluated
     with pytest.raises(ValueError):
-        kernels.Constant(jnp.ones(3))
+        k1 = kernels.Constant(jnp.ones(3))
+        v = jnp.ones(3)
+        k1.evaluate(v, v)
 
-    # ... or when multiplied
+    # Check for dimension issues when multiplied and evaluated.
+    k = jnp.ones(3) * kernels.Matern32(1.5)
     with pytest.raises(ValueError):
-        jnp.ones(3) * kernels.Matern32(1.5)
+        k.evaluate(v, v)
 
     # Check that multiplication has the expected behavior
     factor = 2.5


### PR DESCRIPTION
@dfm Sorry -- I SNAFU'd my other PR on accident with my poor local `git` abilities.

This is a continuation of #146 -- and moves the `post_init` check into `evaluate` for kernels which perform the check.

Re -- I'm not sure if my moving of `assert ...` until after the checks will mess up typechecking -- let me know if you end up having a moment.