### PR TITLE
Fixed minor doc error (no code change)

### DIFF
--- a/src/tinygp/kernels/stationary.py
+++ b/src/tinygp/kernels/stationary.py
@@ -144,7 +144,7 @@ class Matern52(Stationary):
     .. math::
 
         k(\mathbf{x}_i,\,\mathbf{x}_j) = (1 + \sqrt{5}\,r +
-            5\,r^2/\sqrt{3})\,\exp(-\sqrt{5}\,r)
+            5\,r^2/3)\,\exp(-\sqrt{5}\,r)
 
     where, by default,
 


### PR DESCRIPTION
Error in documentation of Matern52 (division by sqrt(3) instead of division by 3). Trivial