### PR TITLE
Attempt to make CARMA kernel jit-compliant

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -39,6 +39,12 @@
       "affiliation": "Department of Astronomy and the DiRAC Institute, University of Washington, Seattle, WA, USA",
       "name": "Caplar, Neven"
     }
+    {
+      "orcid": "0000-0002-1169-7486",
+      "affiliation": "SRON Netherlands Institute for Space Research, Leiden, The Netherlands",
+      "name": "Huppenkothen, Daniela"
+    }
+
   ],
   "license": "MIT",
   "title": "dfm/tinygp: The tiniest of Gaussian Process libraries",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -38,7 +38,7 @@
       "orcid": "0000-0003-3287-5250",
       "affiliation": "Department of Astronomy and the DiRAC Institute, University of Washington, Seattle, WA, USA",
       "name": "Caplar, Neven"
-    }
+    },
     {
       "orcid": "0000-0002-1169-7486",
       "affiliation": "SRON Netherlands Institute for Space Research, Leiden, The Netherlands",

--- a/news/188.bugfix
+++ b/news/188.bugfix
@@ -1,0 +1,1 @@
+Fixed use of `jnp.roots` and `np.roll` to make CARMA kernel jit-compliant

--- a/src/tinygp/kernels/quasisep.py
+++ b/src/tinygp/kernels/quasisep.py
@@ -687,7 +687,7 @@ class CARMA(Quasisep):
         # We find the roots of the autoregressive polynomial as a means to find
         # the eigendecomposition of the design matrix.
         alpha_ext = jnp.append(alpha, 1.0)
-        roots = jnp.roots(alpha_ext[::-1])
+        roots = jnp.roots(alpha_ext[::-1], strip_zeros=False)
         proj = roots[:, None] ** jnp.arange(p)[None, :]
         proj_inv = jnp.linalg.inv(proj)
 
@@ -716,7 +716,7 @@ class CARMA(Quasisep):
         # strictly real-valued.
         f = 2 * ((np.arange(2 * p) // 2) % 2) - 1
         x = f * jnp.append(alpha_ext, jnp.zeros(p - 1))
-        params = jnp.stack([np.roll(x, k)[::2] for k in range(p)], axis=0)
+        params = jnp.stack([jnp.roll(x, k)[::2] for k in range(p)], axis=0)
         params = jnp.linalg.solve(params, 0.5 * sigma**2 * jnp.eye(p, 1, k=-p + 1))[
             :, 0
         ]


### PR DESCRIPTION
I'm currently trying to get the CARMA model working with JaxNS, and am running into jit-compiler issues that I've tracked down to the different behaviour between `jax.numpy.roots` and `numpy.roots`, and the use of the numpy `roll` function.

These seem like small fixes, but I won't pretend I really understand either JAX jit or tinygp in enough detail to know whether it breaks anything.

Looking at the issues (which I guess I should have done before), it looks like I'm not the first person to find this error (cf #89), but I don't know if #90 will solve this issue (or what the current status of this PR is?)