### PR TITLE
Exploit band-diagonal structure in quasisep transitions for better scaling

### DIFF
--- a/src/tinygp/solvers/kalman.py
+++ b/src/tinygp/solvers/kalman.py
@@ -101,6 +101,8 @@ def kalman_gains(
         return Pk, (sk, Kk)
 
     init = Pinf
+    if hasattr(init, "to_dense"):
+        init = init.to_dense()
     return jax.lax.scan(step, init, (A, H, diag))[1]
 
 

--- a/src/tinygp/solvers/quasisep/block.py
+++ b/src/tinygp/solvers/quasisep/block.py
@@ -1,0 +1,120 @@
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.scipy.linalg import block_diag
+
+from tinygp.helpers import JAXArray
+
+
+class Block(eqx.Module):
+    blocks: tuple[Any, ...]
+    __array_priority__ = 1999
+
+    def __init__(self, *blocks: Any):
+        self.blocks = blocks
+
+    def __getitem__(self, idx: Any) -> "Block":
+        return Block(*(b[idx] for b in self.blocks))
+
+    def __len__(self) -> int:
+        assert all(np.ndim(b) == 2 for b in self.blocks)
+        return sum(len(b) for b in self.blocks)
+
+    @property
+    def ndim(self) -> int:
+        ndim, = {np.ndim(b) for b in self.blocks}
+        return ndim
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        size = len(self)
+        return (size, size)
+
+    def transpose(self) -> "Block":
+        return Block(*(b.transpose() for b in self.blocks))
+
+    @property
+    def T(self) -> "Block":
+        return self.transpose()
+
+    def to_dense(self) -> JAXArray:
+        assert all(np.ndim(b) == 2 for b in self.blocks)
+        return block_diag(*self.blocks)
+
+    @jax.jit
+    def __mul__(self, other: Any) -> "Block":
+        return Block(*(b * other for b in self.blocks))
+
+    @jax.jit
+    def __add__(self, other: Any) -> Any:
+        if isinstance(other, Block):
+            assert len(self) == len(other)
+            assert all(
+                np.shape(b1) == np.shape(b2)
+                for b1, b2 in zip(self.blocks, other.blocks)
+            )
+            return Block(*(b1 + b2 for b1, b2 in zip(self.blocks, other.blocks)))
+        else:
+            # TODO(dfm): This could be optimized to avoid converting to dense.
+            return self.to_dense() + other
+
+    def __radd__(self, other: Any) -> Any:
+        # TODO(dfm): This could be optimized to avoid converting to dense.
+        return other + self.to_dense()
+
+    @jax.jit
+    def __sub__(self, other: Any) -> Any:
+        if isinstance(other, Block):
+            assert len(self) == len(other)
+            assert all(
+                np.shape(b1) == np.shape(b2)
+                for b1, b2 in zip(self.blocks, other.blocks)
+            )
+            return Block(*(b1 - b2 for b1, b2 in zip(self.blocks, other.blocks)))
+        else:
+            # TODO(dfm): This could be optimized to avoid converting to dense.
+            return self.to_dense() - other
+
+    def __rsub__(self, other: Any) -> Any:
+        # TODO(dfm): This could be optimized to avoid converting to dense.
+        return other - self.to_dense()
+
+    @jax.jit
+    def __matmul__(self, other: Any) -> Any:
+        if isinstance(other, Block):
+            assert len(self.blocks) == len(other.blocks)
+            assert all(
+                np.shape(b1) == np.shape(b2)
+                for b1, b2 in zip(self.blocks, other.blocks)
+            )
+            return Block(*(b1 @ b2 for b1, b2 in zip(self.blocks, other.blocks)))
+        assert all(np.ndim(b) == 2 for b in self.blocks)
+        ndim = np.ndim(other)
+        assert ndim >= 1
+        idx = 0
+        ys = []
+        for b in self.blocks:
+            size = len(b)
+            x = (
+                other[idx : idx + size]
+                if ndim == 1
+                else other[..., idx : idx + size, :]
+            )
+            ys.append(b @ x)
+            idx += size
+        return jnp.concatenate(ys) if ndim == 1 else jnp.concatenate(ys, axis=-2)
+
+    @jax.jit
+    def __rmatmul__(self, other: Any) -> Any:
+        assert all(np.ndim(b) == 2 for b in self.blocks)
+        idx = 0
+        ys = []
+        for b in self.blocks:
+            size = len(b)
+            x = other[..., idx : idx + size]
+            ys.append(x @ b)
+            idx += size
+        return jnp.concatenate(ys, axis=-1)

--- a/src/tinygp/solvers/quasisep/block.py
+++ b/src/tinygp/solvers/quasisep/block.py
@@ -25,7 +25,7 @@ class Block(eqx.Module):
 
     @property
     def ndim(self) -> int:
-        ndim, = {np.ndim(b) for b in self.blocks}
+        (ndim,) = {np.ndim(b) for b in self.blocks}
         return ndim
 
     @property

--- a/tests/test_kernels/test_quasisep.py
+++ b/tests/test_kernels/test_quasisep.py
@@ -61,8 +61,14 @@ def test_quasisep_kernels(data, kernel):
     # Test that F is defined consistently
     x1 = x[0]
     x2 = x[1]
-    num_A = jsp.linalg.expm(kernel.design_matrix().T * (x2 - x1))
-    assert_allclose(kernel.transition_matrix(x1, x2), num_A)
+    arg = kernel.design_matrix().T * (x2 - x1)
+    if hasattr(arg, "to_dense"):
+        arg = arg.to_dense()
+    expected = jsp.linalg.expm(arg)
+    calculated = kernel.transition_matrix(x1, x2)
+    if hasattr(calculated, "to_dense"):
+        calculated = calculated.to_dense()
+    assert_allclose(calculated, expected)
 
 
 def test_quasisep_kernel_as_pytree(data, kernel):

--- a/tests/test_solvers/test_quasisep/test_block.py
+++ b/tests/test_solvers/test_quasisep/test_block.py
@@ -1,0 +1,31 @@
+# mypy: ignore-errors
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from scipy.linalg import block_diag
+
+from tinygp.solvers.quasisep.block import Block
+from tinygp.test_utils import assert_allclose
+
+
+@pytest.fixture(params=[(10,), (10, 3), (4, 10, 3), (2, 4, 10, 3)])
+def block_params(request):
+    shape = request.param
+    random = np.random.default_rng(1234)
+    block_sizes = [1, 3, 2, 4]
+    block = Block(*(random.uniform(size=(s, s)) for s in block_sizes))
+    x = random.uniform(size=shape)
+    return block, x
+
+
+def test_block(block_params):
+    block, x = block_params
+    xt = x if len(x.shape) == 1 else jnp.swapaxes(x, -1, -2)
+    block_ = block_diag(*block.blocks)
+    assert len(block) == len(block_)
+    assert block.shape == block_.shape
+    assert_allclose(block @ x, block_ @ x)
+    assert_allclose(xt @ block, xt @ block_)
+    assert_allclose(block.T @ x, block_.T @ x)
+    assert_allclose(xt @ block.T, xt @ block_.T)


### PR DESCRIPTION
This PR builds on the fact that most real applications of quasiseparable kernels have internal block diagonal structure. If we ignore this fact than the computational cost scales as the cube of the model "width" (approximately the number of kernel terms), but we can get better scaling (quadratic in width) if we exploit this structure.

Here is the scaling in model width before and after this change:

![runtime](https://github.com/user-attachments/assets/2f834e46-6459-4ad6-9a1c-c4df9c36f61a)

As expected, for wide models, this makes a dramatic difference in the runtime performance.

I'll note that we do end up paying a non-trivial compile time cost:

![compile](https://github.com/user-attachments/assets/9a39ad4b-8e11-4471-8fd2-046970978609)

But I think that that's probably worth it.

(Note that in all these examples I've set the environment variable: `XLA_FLAGS=--xla_backend_extra_options=xla_cpu_small_while_loop_byte_threshold=1000000`.)

In this PR, I'll enable the new behavior by default, but we could consider adding an option to disable it.